### PR TITLE
Rebrand Kentico Cloud to Kontent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Sorry to hear that. Just log a new [GitHub issue](../../issues) and someone will
 <img align="right" width="100" height="100" src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-icon.svg">
 
 To get help with coding and structuring your projects, use [StackOverflow](https://stackoverflow.com/) to ask questions with one of the following tags:
-- [`kentico-cloud`](https://stackoverflow.com/questions/tagged/kentico-cloud)
+- [`kentico-kontent`](https://stackoverflow.com/questions/tagged/kentico-kontent)
 - [`kentico`](https://stackoverflow.com/questions/tagged/kentico)
 
 Our team members and the community monitor these channels on a regular basis.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This will bootstrap the site, build all static pages and start the site at http:
 
 You may use any IDE, however, we've added a [settings file](https://github.com/Kentico/gatsby-starter-kentico-cloud/blob/master/.vscode/launch.json) for [Visual Studio Code](https://code.visualstudio.com/) for easier debugging.
 
-To get a smooth debugging experience, you can temporarily copy the `gatsby-source-kontent` [directory](https://github.com/Kentico/gatsby-source-kontent) of the source plugin to the `/plugins/@kentico` directory of your site. Then, run int the context of `/plugins/@kentico/gatsby-source-kontent` two commands `npm install` and `npm run build`.
+To get a smooth debugging experience, you can temporarily copy the `gatsby-source-kontent` [directory](https://github.com/Kentico/gatsby-source-kontent) of the source plugin to the `/plugins/@kentico/gatsby-source-kontent` directory of your site. Then, in the context of `/plugins/@kentico/gatsby-source-kontent`, run two commands `npm install` and `npm run build`.
 
 ### Using the Kentico Kontent JavaScript SDK configuration object
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This will bootstrap the site, build all static pages and start the site at http:
 
 You may use any IDE, however, we've added a [settings file](https://github.com/Kentico/gatsby-starter-kentico-cloud/blob/master/.vscode/launch.json) for [Visual Studio Code](https://code.visualstudio.com/) for easier debugging.
 
-To get a smooth debugging experience, you can temporarily copy the `gatsby-source-kontent` [directory](https://github.com/Kentico/gatsby-source-kontent) of the source plugin to the `/plugins/@kentico/gatsby-source-kontent` directory of your site. Then, run int the context of `/plugins/@kentico/gatsby-source-kontent` two commands `npm install` and `npm run build`.
+To get a smooth debugging experience, you can temporarily copy the `gatsby-source-kontent` [directory](https://github.com/Kentico/gatsby-source-kontent) of the source plugin to the `/plugins/@kentico` directory of your site. Then, run int the context of `/plugins/@kentico/gatsby-source-kontent` two commands `npm install` and `npm run build`.
 
 ### Using the Kentico Kontent JavaScript SDK configuration object
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Gatsby starter site with Kentico Cloud
+# Gatsby starter site with Kentico Kontent
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/78b48df8-68df-4b9a-9dfc-91803d8a77d8/deploy-status)](https://app.netlify.com/sites/gatsby-starter-kentico-cloud/deploys)
 
 [![Live demo](https://img.shields.io/badge/-Live%20Demo-brightgreen.svg)](https://gatsby-starter-kentico-cloud.netlify.com/)
-[![Stack Overflow](https://img.shields.io/badge/Stack%20Overflow-ASK%20NOW-FE7A16.svg?logo=stackoverflow&logoColor=white)](https://stackoverflow.com/tags/kentico-cloud)
+[![Stack Overflow](https://img.shields.io/badge/Stack%20Overflow-ASK%20NOW-FE7A16.svg?logo=stackoverflow&logoColor=white)](https://stackoverflow.com/tags/kentico-kontent)
 
-This repo contains a [Gatsby v2 starter site](https://www.gatsbyjs.org/starters/Kentico/gatsby-starter-kentico-cloud/) preconfigured with [Kentico Cloud](https://www.kenticocloud.com/) [source plugin](https://www.npmjs.com/package/gatsby-source-kentico-cloud). The site portrays a personal site of a fictional technical evangelist that attends user groups, writes blog posts and implements projects.
+This repo contains a [Gatsby v2 starter site](https://www.gatsbyjs.org/starters/Kentico/gatsby-starter-kentico-cloud/) preconfigured with [Kentico Kontent](https://kontent.ai/) [source plugin](https://www.npmjs.com/package/@kentico/gatsby-source-kontent). The site portrays a personal site of a fictional technical evangelist that attends user groups, writes blog posts and implements projects.
 
-![Gatsby starter site with Kentico Cloud](https://i.imgur.com/xvASA35.png)
+![Gatsby starter site with Kentico Kontent](https://i.imgur.com/xvASA35.png)
 
 ## Prerequisites
 
@@ -45,16 +45,16 @@ This will bootstrap the site, build all static pages and start the site at http:
 
 You may use any IDE, however, we've added a [settings file](https://github.com/Kentico/gatsby-starter-kentico-cloud/blob/master/.vscode/launch.json) for [Visual Studio Code](https://code.visualstudio.com/) for easier debugging.
 
-To get a smooth debugging experience, you can temporarily copy the `gatsby-source-kentico-cloud` [directory](https://github.com/Kentico/gatsby-source-kentico-cloud) of the source plugin to the `/plugins` directory of your site. Then, move the `gatsby-node.js` and `normalize.js` files from `/plugins/gatsby-source-kentico-cloud/src` to `/plugins/gatsby-source-kentico-cloud` (up one level).
+To get a smooth debugging experience, you can temporarily copy the `gatsby-source-kontent` [directory](https://github.com/Kentico/gatsby-source-kontent) of the source plugin to the `/plugins/@kentico/gatsby-source-kontent` directory of your site. Then, run int the context of `/plugins/@kentico/gatsby-source-kontent` two commands `npm install` and `npm run build`.
 
-### Using the Kentico Cloud JavaScript SDK configuration object
+### Using the Kentico Kontent JavaScript SDK configuration object
 
-The source plugin used by this starter in turn uses the [Kentico Cloud Delivery SDK](https://github.com/Kentico/kentico-cloud-js/tree/master/packages/delivery#kentico-cloud-delivery-sdk) in the background. You can put the [configuration object](https://github.com/Kentico/kentico-cloud-js/blob/master/packages/delivery/DOCS.md#client-configuration) of the SDK into the `deliveryClientConfig` property of the [gatsby-config.js](https://github.com/Kentico/gatsby-starter-kentico-cloud/blob/master/gatsby-config.js) file.
+The source plugin used by this starter in turn uses the [Kentico Kontent Delivery SDK](https://github.com/Kentico/kontent-delivery-sdk-js) in the background. You can put the [configuration object](https://github.com/Kentico/kontent-delivery-sdk-js/blob/v8.0.0/DOCS.md#client-configuration) of the SDK into the `deliveryClientConfig` property of the [gatsby-config.js](/gatsby-config.js) file.
 
 ### Experimenting
 
-Of all the artifacts of Kentico Cloud, the starter site only displays content items and only in the default language. But, our [source plugin](https://github.com/Kentico/gatsby-source-kentico-cloud) also provides content types and items in non-default languages. The plugin links them all so that these data can be fetched in one GraphQL query.
+Of all the artifacts of Kentico Kontent, the starter site only displays content items and only in the default language. But, our [source plugin](https://github.com/Kentico/gatsby-source-kontent) also provides content types and items in non-default languages. The plugin links them all so that these data can be fetched in one GraphQL query.
 
-Check out the [source plugin](https://github.com/Kentico/gatsby-source-kentico-cloud#features) for more details on which kinds of data and relationships it supports.
+Check out the [source plugin](https://github.com/Kentico/gatsby-source-kontent#features) for more details on which kinds of data and relationships it supports.
 
 ![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/gatsby-starter-kentico-cloud?pixel)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Gatsby starter site with Kentico Kontent
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/78b48df8-68df-4b9a-9dfc-91803d8a77d8/deploy-status)](https://app.netlify.com/sites/gatsby-starter-kentico-cloud/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/78b48df8-68df-4b9a-9dfc-91803d8a77d8/deploy-status)](https://app.netlify.com/sites/gatsby-starter-kontent/deploys)
 
-[![Live demo](https://img.shields.io/badge/-Live%20Demo-brightgreen.svg)](https://gatsby-starter-kentico-cloud.netlify.com/)
+[![Live demo](https://img.shields.io/badge/-Live%20Demo-brightgreen.svg)](https://gatsby-starter-kontent.netlify.com/)
 [![Stack Overflow](https://img.shields.io/badge/Stack%20Overflow-ASK%20NOW-FE7A16.svg?logo=stackoverflow&logoColor=white)](https://stackoverflow.com/tags/kentico-kontent)
 
-This repo contains a [Gatsby v2 starter site](https://www.gatsbyjs.org/starters/Kentico/gatsby-starter-kentico-cloud/) preconfigured with [Kentico Kontent](https://kontent.ai/) [source plugin](https://www.npmjs.com/package/@kentico/gatsby-source-kontent). The site portrays a personal site of a fictional technical evangelist that attends user groups, writes blog posts and implements projects.
+This repo contains a [Gatsby v2 starter site](https://www.gatsbyjs.org/starters/Kentico/gatsby-starter-kontent/) pre-configured with [Kentico Kontent](https://kontent.ai/) [source plugin](https://www.npmjs.com/package/@kentico/gatsby-source-kontent). The site portrays a personal site of a fictional technical evangelist that attends user groups, writes blog posts and implements projects.
 
 ![Gatsby starter site with Kentico Kontent](https://i.imgur.com/xvASA35.png)
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = {
   plugins: [
     `gatsby-plugin-react-helmet`,
     {
-      resolve: `gatsby-source-kentico-cloud`,
+      resolve: `@kentico/gatsby-source-kontent`,
       options: {
         deliveryClientConfig: {
           projectId: `5ac93d1e-567d-01e6-e3b7-ac435f77b907`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    title: `Gatsby starter site with Kentico Cloud`,
+    title: `Gatsby starter site with Kentico Kontent`,
   },
   plugins: [
     `gatsby-plugin-react-helmet`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,11 +1,11 @@
 const path = require(`path`);
 const _ = require(`lodash`);
-const kcItemTypeIdentifier = `KenticoCloudItem`;
+const kcItemTypeIdentifier = `KontentItem`;
 const projectReferenceTypeIdentifier = `ProjectReference`;
 const speakingEngagementTypeIdentifier = `SpeakingEngagement`;
 
 exports.onCreateNode = ({ node, actions: { createNodeField } }) => {
-  if (_.has(node, `internal.type`) && _.isString(node.internal.type) && node.internal.type.startsWith(`KenticoCloudItem`)) {
+  if (_.has(node, `internal.type`) && _.isString(node.internal.type) && node.internal.type.startsWith(kcItemTypeIdentifier)) {
     let withDetailView = false;
     let templateName;
 
@@ -43,59 +43,53 @@ exports.onCreateNode = ({ node, actions: { createNodeField } }) => {
 exports.createPages = ({ graphql, actions }) => {
   const { createPage } = actions;
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve, _reject) => {
     graphql(`
     {
-      allKenticoCloudItemBlogpostReference {
-        edges {
-          node {
-            fields {
-              language
-            }
+      allKontentItemBlogpostReference {
+        nodes {
+          fields {
+            language
           }
         }
       }
-      allKenticoCloudItemProjectReference {
-        edges {
-          node {
-            fields {
-              templateName
-              slug
-              language
-            }
+      allKontentItemProjectReference {
+        nodes {
+          fields {
+            templateName
+            slug
+            language
           }
         }
       }
-      allKenticoCloudItemSpeakingEngagement {
-        edges {
-          node {
-            fields {
-              templateName
-              slug
-              language
-            }
+      allKontentItemSpeakingEngagement {
+        nodes {
+          fields {
+            templateName
+            slug
+            language
           }
         }
       }
     }
     `).then(result => {
-        const union = result.data.allKenticoCloudItemProjectReference.edges.concat(result.data.allKenticoCloudItemSpeakingEngagement.edges);
+      const union = result.data.allKontentItemProjectReference.nodes.concat(result.data.allKontentItemSpeakingEngagement.nodes);
 
-        union.forEach(({ node }) => {
-            if (_.has(node, `fields.templateName`) && !_.isNil(node.fields.templateName)) {
-            createPage({
-              path: `${node.fields.templateName}/${node.fields.slug}`,
-              component: path.resolve(`./src/templates/${node.fields.templateName}.js`),
-              context: {
-                // Data passed to context is available in page queries as GraphQL variables.
-                templateName: node.fields.templateName,
-                slug: node.fields.slug,
-                language: node.fields.language
-              },
-            });
-          }
-        });
-        resolve();
+      union.forEach(({ node }) => {
+        if (_.has(node, `fields.templateName`) && !_.isNil(node.fields.templateName)) {
+          createPage({
+            path: `${node.fields.templateName}/${node.fields.slug}`,
+            component: path.resolve(`./src/templates/${node.fields.templateName}.js`),
+            context: {
+              // Data passed to context is available in page queries as GraphQL variables.
+              templateName: node.fields.templateName,
+              slug: node.fields.slug,
+              language: node.fields.language
+            },
+          });
+        }
       });
+      resolve();
+    });
   });
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -43,17 +43,10 @@ exports.onCreateNode = ({ node, actions: { createNodeField } }) => {
 exports.createPages = ({ graphql, actions }) => {
   const { createPage } = actions;
 
-  return new Promise((resolve, _reject) => {
+  return new Promise((resolve) => {
     graphql(`
     {
-      allKontentItemBlogpostReference {
-        nodes {
-          fields {
-            language
-          }
-        }
-      }
-      allKontentItemProjectReference {
+      allKontentItemProjectReference (filter: {preferred_language: {eq: "default"}}) {
         nodes {
           fields {
             templateName
@@ -62,7 +55,7 @@ exports.createPages = ({ graphql, actions }) => {
           }
         }
       }
-      allKontentItemSpeakingEngagement {
+      allKontentItemSpeakingEngagement (filter: {preferred_language: {eq: "default"}}){
         nodes {
           fields {
             templateName
@@ -75,7 +68,7 @@ exports.createPages = ({ graphql, actions }) => {
     `).then(result => {
       const union = result.data.allKontentItemProjectReference.nodes.concat(result.data.allKontentItemSpeakingEngagement.nodes);
 
-      union.forEach(({ node }) => {
+      union.forEach(( node ) => {
         if (_.has(node, `fields.templateName`) && !_.isNil(node.fields.templateName)) {
           createPage({
             path: `${node.fields.templateName}/${node.fields.slug}`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,19 +1,19 @@
 const path = require(`path`);
 const _ = require(`lodash`);
-const kcItemTypeIdentifier = `KontentItem`;
+const kontentItemTypeIdentifier = `KontentItem`;
 const projectReferenceTypeIdentifier = `ProjectReference`;
 const speakingEngagementTypeIdentifier = `SpeakingEngagement`;
 
 exports.onCreateNode = ({ node, actions: { createNodeField } }) => {
-  if (_.has(node, `internal.type`) && _.isString(node.internal.type) && node.internal.type.startsWith(kcItemTypeIdentifier)) {
+  if (_.has(node, `internal.type`) && _.isString(node.internal.type) && node.internal.type.startsWith(kontentItemTypeIdentifier)) {
     let withDetailView = false;
     let templateName;
 
-    if (node.internal.type === `${kcItemTypeIdentifier}${projectReferenceTypeIdentifier}`) {
+    if (node.internal.type === `${kontentItemTypeIdentifier}${projectReferenceTypeIdentifier}`) {
       templateName = `project-reference`;
       withDetailView = true;
     }
-    else if (node.internal.type === `${kcItemTypeIdentifier}${speakingEngagementTypeIdentifier}`) {
+    else if (node.internal.type === `${kontentItemTypeIdentifier}${speakingEngagementTypeIdentifier}`) {
       templateName = `speaking-engagement`;
       withDetailView = true;
     }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "author": "Jan Lenoch <janl@kentico.com>",
   "license": "MIT",
   "dependencies": {
+    "@kentico/gatsby-source-kontent": "4.0.0-beta2",
     "gatsby": "^2.0.22",
     "gatsby-plugin-react-helmet": "^3.0.0",
-    "gatsby-source-kentico-cloud": "^3.0.0",
     "react": "^16.5.1",
     "react-dom": "^16.5.1",
     "react-helmet": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gatsby-starter-kentico-cloud",
+  "name": "gatsby-starter-kontent",
   "version": "1.1.1",
-  "description": "Gatsby starter site with Kentico Cloud",
+  "description": "Gatsby starter site with Kentico kontent",
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
@@ -11,13 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Kentico/gatsby-starter-kentico-cloud"
+    "url": "https://github.com/Kentico/gatsby-starter-kontent"
   },
   "keywords": [
     "gatsby",
     "Gatsby",
-    "kentico-cloud",
-    "Kentico Cloud",
+    "kentico-kontent",
+    "Kentico Kontent",
+    "caas",
     "starter",
     "Starter"
   ],

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -21,8 +21,8 @@ const Layout = ({children}) => (
         <Helmet
           title={data.site.siteMetadata.title}
           meta={[
-            {name: `description`, content: `Gatsby starter site with Kentico Cloud`},
-            {name: `keywords`, content: `Kentico Cloud, Gatsby, starter`},
+            {name: `description`, content: `Gatsby starter site with Kentico Kontent`},
+            {name: `keywords`, content: `Kentico Kontent, Gatsby, starter`},
           ]}
         />
         <Header siteTitle={data.site.siteMetadata.title} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,7 +4,7 @@ import { Link, graphql } from 'gatsby';
 import Layout from '../components/layout';
 
 const Index = ({data}) => {
-  const union = data.allKenticoCloudItemBlogpostReference.edges.concat(data.allKenticoCloudItemProjectReference.edges).concat(data.allKenticoCloudItemSpeakingEngagement.edges);
+  const union = data.allKontentItemBlogpostReference.edges.concat(data.allKontentItemProjectReference.edges).concat(data.allKontentItemSpeakingEngagement.edges);
 
   const items = union.map(({node}) => {
     if (node.fields && node.fields !== null && node.fields.templateName && node.fields.templateName !== null) {
@@ -41,7 +41,7 @@ export default Index;
 
 export const query = graphql`
   {
-    allKenticoCloudItemBlogpostReference(filter: { fields: { language: { eq: "default" }}}) {
+    allKontentItemBlogpostReference(filter: { fields: { language: { eq: "default" }}}) {
       edges {
         node {
           fields {
@@ -59,7 +59,7 @@ export const query = graphql`
         }
       }
     }
-    allKenticoCloudItemProjectReference(filter: { fields: { language: { eq: "default" }}}) {
+    allKontentItemProjectReference(filter: { fields: { language: { eq: "default" }}}) {
       edges {
         node {
           fields {
@@ -79,7 +79,7 @@ export const query = graphql`
         }
       }
     }
-    allKenticoCloudItemSpeakingEngagement(filter: { fields: { language: { eq: "default" }}}) {
+    allKontentItemSpeakingEngagement(filter: { fields: { language: { eq: "default" }}}) {
       edges {
         node {
           fields {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -41,11 +41,27 @@ export default Index;
 
 export const query = graphql`
   {
-    allKontentItemBlogpostReference(filter: { fields: { language: { eq: "default" }}}) {
+    allKontentItemBlogpostReference(filter: {preferred_language: {eq: "default"}}) {
+      edges {
+        node {
+          id
+          elements {
+            url {
+              value
+            }
+            name___teaser_image__name {
+              value
+            }
+          }
+        }
+      }
+    }
+    allKontentItemProjectReference(filter: {preferred_language: {eq: "default"}}) {
       edges {
         node {
           fields {
-            language
+            templateName
+            slug
           }
           id
           elements {
@@ -59,33 +75,12 @@ export const query = graphql`
         }
       }
     }
-    allKontentItemProjectReference(filter: { fields: { language: { eq: "default" }}}) {
+    allKontentItemSpeakingEngagement(filter: {preferred_language: {eq: "default"}}) {
       edges {
         node {
           fields {
             templateName
             slug
-            language
-          }
-          id
-          elements {
-            url {
-              value
-            }
-            name___teaser_image__name {
-              value
-            }
-          }
-        }
-      }
-    }
-    allKontentItemSpeakingEngagement(filter: { fields: { language: { eq: "default" }}}) {
-      edges {
-        node {
-          fields {
-            templateName
-            slug
-            language
           }
           id
           elements {

--- a/src/templates/project-reference.js
+++ b/src/templates/project-reference.js
@@ -5,7 +5,7 @@ import Layout from '../components/layout';
 import { formatDate } from '../helpers/date-time';
 
 const ProjectReference = ({data}) => {
-  const item = data.kenticoCloudItemProjectReference;
+  const item = data.kontentItemProjectReference;
 
   return (
     <Layout>
@@ -41,7 +41,7 @@ export const query = graphql`
         title
       }
     }
-    kenticoCloudItemProjectReference(fields: { slug: { eq: $slug }}) {
+    kontentItemProjectReference(fields: { slug: { eq: $slug }}) {
       system {
         name
       }

--- a/src/templates/speaking-engagement.js
+++ b/src/templates/speaking-engagement.js
@@ -5,7 +5,7 @@ import Layout from '../components/layout';
 import { formatDate } from '../helpers/date-time';
 
 const SpeakingEngagement = ({data}) => {
-  const item = data.kenticoCloudItemSpeakingEngagement;
+  const item = data.kontentItemSpeakingEngagement;
 
   return (
     <Layout>
@@ -44,7 +44,7 @@ export const query = graphql`
         title
       }
     }
-    kenticoCloudItemSpeakingEngagement(fields: { slug: { eq: $slug }}) {
+    kontentItemSpeakingEngagement(fields: { slug: { eq: $slug }}) {
       system {
         name
       }


### PR DESCRIPTION
### Motivation

Rebrand [Kentico Cloud to Kentico Kontent](https://kontent.ai/blog/moving-to-caas-with-kentico-kontent)

See the guidelines at https://gitter.im/Kentico/Kontent?at=5d8b643d692d464f7969c6d9.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
Check source code for missing renaming.
Test whether the starter works